### PR TITLE
made kerberos an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setup(name='jupyterhub-kdcauthenticator',
       author_email='jchakrabort5@bloomberg.net',
       license='3 Clause BSD',
       packages=['kdcauthenticator'],
+      install_requires=[
+          'kerberos',
+      ],
       zip_safe=False)


### PR DESCRIPTION
I noticed that the kerberos package is an install dependency and have therefore stated that as such in the setup.py